### PR TITLE
add: columns for passing on from charon to ega for entity

### DIFF
--- a/eevee/metrics/entity.py
+++ b/eevee/metrics/entity.py
@@ -51,6 +51,13 @@ def dump_error_reports(df: pd.DataFrame, fp_error_idxs, fn_error_idxs, mm_errror
 
     df.drop(labels=["index", "true", "pred", "entity_comp_results"], axis=1, inplace=True)
     df.rename(columns={"entities_x": "true_entities", "entities_y": "pred_entities"}, inplace=True)
+    
+    columns_we_should_give = ["id", "true_entities", "pred_entities", "true_ent_type", "pred_ent_type"]
+    columns_that_help_with_ega =  ["call_uuid", "conversation_uuid", "alternatives", "audio_url", "prediction", "state"]
+
+    # just to make the order of columns easy to grasp.
+    if pd.Series(columns_that_help_with_ega).isin(df.columns).all():
+        df = df[columns_we_should_give + columns_that_help_with_ega]
 
     fp_df = df.loc[df.index[fp_error_idxs]]
     fn_df = df.loc[df.index[fn_error_idxs]]

--- a/scripts/charon_tagged_to_predicted_entities.py
+++ b/scripts/charon_tagged_to_predicted_entities.py
@@ -1,5 +1,5 @@
 """
-Script for picking predicted_entities from charon's tagged_data.csv,
+Script for picking predicted_entities (along with other columns that help with EGA) from charon's tagged_data.csv,
 and saving it in a different file.
 
 Usage:
@@ -16,7 +16,13 @@ from docopt import docopt
 
 def convert(input_path, output_path):
 
-    df = pd.read_csv(input_path, usecols=["id", "predicted_entities"])
+    usecols = [
+        "id", "predicted_entities", 
+        "call_uuid", "conversation_uuid",
+        "alternatives", "audio_url", "prediction", "state"
+    ]
+
+    df = pd.read_csv(input_path, usecols=usecols)
     df = df.rename(columns={"predicted_entities": "entities"})
     df.to_csv(output_path, index=False)
 


### PR DESCRIPTION
eevee doesn't have any preference on columns.
it just passes on the input truth and pred dataframes, but the `charon_tagged_to_predicted_entities.py` was limiting what information needs to be passed on (accidentally).

so yeah, modified it to give out whatever is necessary (but not to make the dump files bloated)