### PR TITLE
Evaluate ASR metrics for noisy and non-noisy subsets

### DIFF
--- a/docs/metrics/asr.md
+++ b/docs/metrics/asr.md
@@ -86,8 +86,8 @@ eevee asr ./data/tagged.transcriptions.csv ./data/predicted.transcriptions.csv -
 ```
 
 Results are in two DataFrames - for each of `noisy` and `non-noisy` subsets, in order. An important note 
-here, is that the transcriptions in `tagged.transcriptions.csv` are expected to contain informational tags,
-like - `<audio_silent>`, `<inaudible>`, etc - which are normally removed when not using the "--noisy" flag.
+here, is that the transcriptions in `tagged.transcriptions.csv` are expected to contain info tags, like -
+`<audio_silent>`, `<inaudible>`, etc - which aren't expected when not using the "--noisy" flag.
 
 ### Python module
 
@@ -99,6 +99,42 @@ like - `<audio_silent>`, `<inaudible>`, etc - which are normally removed when no
 >>> pred_df = pd.read_csv("data/predicted.transcriptions.csv", usecols=["id", "utterances"])
 >>>
 >>> asr_report(true_df, pred_df)
+                    Value   Support
+Metric
+WER                  0.571429        6
+Utterance FPR        0.500000        2
+Utterance FNR        0.250000        4
+SER                  0.666667        6
+Min 3 WER            0.571429        6
+Min WER              0.571429        6
+Short Utterance WER  0.000000        1
+Long Utterance WER   0.809524        3
+
+```
+
+For ASR metrics, segregated by "noisy":
+```python
+>>> import pandas as pd
+>>> from eevee.metrics.asr import asr_report, process_noise_info
+>>>
+>>> true_df = pd.read_csv("data/tagged.transcriptions.csv", usecols=["id", "transcription"])
+>>> pred_df = pd.read_csv("data/predicted.transcriptions.csv", usecols=["id", "utterances"])
+>>>
+>>> noisy_dict, not_noisy_dict = process_noise_info(true_labels, pred_labels)
+>>>
+>>> asr_report(noisy_dict["true"], noisy_dict["pred"])
+                    Value   Support
+Metric
+WER                  0.571429        6
+Utterance FPR        0.500000        2
+Utterance FNR        0.250000        4
+SER                  0.666667        6
+Min 3 WER            0.571429        6
+Min WER              0.571429        6
+Short Utterance WER  0.000000        1
+Long Utterance WER   0.809524        3
+
+>>> asr_report(not_noisy_dict["true"], not_noisy_dict["pred"])
                     Value   Support
 Metric
 WER                  0.571429        6

--- a/docs/metrics/asr.md
+++ b/docs/metrics/asr.md
@@ -76,13 +76,18 @@ This will add two csv files
 
 The filename is based on the prediction filename given by the user
 
-For users who want the breakdown according to noisy/non-noisy audios, using the "--noisy" flag like:
+----                                                                                                                                                                                     
+
+For users who want ASR metrics reported separately on `noisy` and `non-noisy` subsets of audios, 
+use the "--noisy" flag like:
 
 ```shell
 eevee asr ./data/tagged.transcriptions.csv ./data/predicted.transcriptions.csv --noisy
 ```
 
-results in two DataFrames getting predicted, one each for the noisy/non-noisy classes.
+Results are in two DataFrames - for each of `noisy` and `non-noisy` subsets, in order. An important note 
+here, is that the transcriptions in `tagged.transcriptions.csv` are expected to contain informational tags,
+like - `<audio_silent>`, `<inaudible>`, etc - which are normally removed when not using the "--noisy" flag.
 
 ### Python module
 

--- a/docs/metrics/asr.md
+++ b/docs/metrics/asr.md
@@ -76,6 +76,14 @@ This will add two csv files
 
 The filename is based on the prediction filename given by the user
 
+For users who want the breakdown according to noisy/non-noisy audios, using the "--noisy" flag like:
+
+```shell
+eevee asr ./data/tagged.transcriptions.csv ./data/predicted.transcriptions.csv --noisy
+```
+
+results in two DataFrames getting predicted, one each for the noisy/non-noisy classes.
+
 ### Python module
 
 ```python

--- a/eevee/cli.py
+++ b/eevee/cli.py
@@ -139,18 +139,22 @@ def main():
         if args["--noisy"]:
 
             noisy_dict, not_noisy_dict = process_noise_info(true_labels, pred_labels)
-            input_dict = {"noisy": noisy_dict,"not-noisy": not_noisy_dict}
+            input_dict = {"noisy": noisy_dict, "not-noisy": not_noisy_dict}
             output_dict = {}
 
             if dump:
                 for key, subset in input_dict.items():
-                    output, breakdown, ops = asr_report(subset["true"], subset["pred"], dump)
+                    output, breakdown, ops = asr_report(
+                        subset["true"], subset["pred"], dump
+                    )
                     output_dict[key] = output
                     breakdown.to_csv(
-                        f'{key}-{args["<pred-labels>"].replace(".csv", "")}-dump.csv', index=False
+                        f'{key}-{args["<pred-labels>"].replace(".csv", "")}-dump.csv',
+                        index=False,
                     )
                     ops.to_csv(
-                        f'{key}-{args["<pred-labels>"].replace(".csv", "")}-ops.csv', index=False
+                        f'{key}-{args["<pred-labels>"].replace(".csv", "")}-ops.csv',
+                        index=False,
                     )
             else:
                 for key, subset in input_dict.items():

--- a/eevee/cli.py
+++ b/eevee/cli.py
@@ -39,7 +39,7 @@ from docopt import docopt
 from eevee import __version__
 from eevee.metrics import intent_report
 from eevee.metrics.classification import intent_layers_report
-from eevee.metrics.asr import asr_report
+from eevee.metrics.asr import asr_report, process_noise_info
 from eevee.metrics.entity import categorical_entity_report, entity_report
 from eevee.utils import parse_yaml
 
@@ -138,12 +138,12 @@ def main():
 
         if args["--noisy"]:
 
-            noisy, not_noisy = process_noise_info(true_labels, pred_labels)
-            data_dict = {"noisy": noisy,"not-noisy": not_noisy}
+            noisy_dict, not_noisy_dict = process_noise_info(true_labels, pred_labels)
+            input_dict = {"noisy": noisy_dict,"not-noisy": not_noisy_dict}
             output_dict = {}
 
             if dump:
-                for key, subset in data_dict.items():
+                for key, subset in input_dict.items():
                     output, breakdown, ops = asr_report(subset["true"], subset["pred"], dump)
                     output_dict[key] = output
                     breakdown.to_csv(
@@ -153,7 +153,7 @@ def main():
                         f'{key}-{args["<pred-labels>"].replace(".csv", "")}-ops.csv', index=False
                     )
             else:
-                for key, subset in data_dict.items():
+                for key, subset in input_dict.items():
                     output = asr_report(subset["true"], subset["pred"])
                     output_dict[key] = output
 

--- a/eevee/metrics/asr.py
+++ b/eevee/metrics/asr.py
@@ -659,12 +659,12 @@ def extract_info_tags(transcription: str) -> str:
     return ""
 
 
-def clean_info_tags(transcription: str) -> str:
+def remove_info_tags(transcription: str) -> str:
     return ""
 
 
 ## change this if you want to change the definition of noisy
-def define_noisy(tag):
+def define_noisy(tag) -> int:
     if tag == "":
         return 0
     elif "silent" in tag:
@@ -685,7 +685,7 @@ def process_noise_info(
     
     ## separate out info tags in transcripts and clean the original transcriptions
     df["info-tag"] = df["transcription"].apply(lambda transcription: extract_info_tags(transcription))
-    df["cleaned-transcription"] = df["transcription"].apply(lambda transcription: clean_info_tags(transcription))
+    df["cleaned-transcription"] = df["transcription"].apply(lambda transcription: remove_info_tags(transcription))
     
     ## separate noisy and not-noisy subsets
     df["noise-label"] = df["info-tag"].apply(lambda tag: define_noisy(tag))

--- a/eevee/metrics/asr.py
+++ b/eevee/metrics/asr.py
@@ -681,12 +681,12 @@ def process_noise_info(
     
     ## separate out info tags in transcripts and clean the original transcriptions
     df["info-tag"] = df["transcription"].apply(lambda trancription: extract_info_tags(trancription))
-    df["cleaned-transcription"] = df["transcription"].apply(lambda transcription: clean_info_tags(trancription))
+    df["cleaned-transcription"] = df["transcription"].apply(lambda transcription: clean_info_tags(transcription))
     
     ## separate noisy and not-noisy subsets
     df["noise-label"] = df["info-tag"].apply(lambda tag: define_noisy(tag))
-    noisy_df = df[df["noise-label"]=="noisy"]
-    not_noisy_df = df[df["noise-label"]!="noisy"]
+    noisy_df = df[df["noise-label"] == "noisy"]
+    not_noisy_df = df[df["noise-label"] != "noisy"]
     
     data_subsets: List = []
     for df in [noisy_df, not_noisy_df]:

--- a/eevee/metrics/asr.py
+++ b/eevee/metrics/asr.py
@@ -747,9 +747,9 @@ def process_noise_info(
     Each dictionary stores the true and predicted labels, for the associated subset, under
     the `true` and `pred` keys respectively.
 
-    NOTE: An "info tag" is an `<>` enclosed substring that conatins information about certain
-    audio events, added during transcription of human speech. If the true lobels dont contain
-    any "info tags", then the sybset for "not noisy" will be empty.
+    NOTE: An "info tag" is an `<>` enclosed substring that contains information about certain
+    audio events, added during transcription of human speech. If the true labels dont contain
+    any "info tags", then the subset for "not noisy" will be empty.
     """
 
     df = pd.merge(true_labels, pred_labels, on="id", how="inner")

--- a/eevee/metrics/asr.py
+++ b/eevee/metrics/asr.py
@@ -666,11 +666,11 @@ def clean_info_tags(transcription: str) -> str:
 ## change this if you want to change the definition of noisy
 def define_noisy(tag):
     if tag is None:
-        return -1
+        return 0
     elif "silent" in tag:
-        return "silent"
+        return 0
     else:
-        return "noisy"
+        return 1
 
 
 def process_noise_info(
@@ -685,8 +685,8 @@ def process_noise_info(
     
     ## separate noisy and not-noisy subsets
     df["noise-label"] = df["info-tag"].apply(lambda tag: define_noisy(tag))
-    noisy_df = df[df["noise-label"] == "noisy"]
-    not_noisy_df = df[df["noise-label"] != "noisy"]
+    noisy_df = df[df["noise-label"] == 1]
+    not_noisy_df = df[df["noise-label"] == 0]
     
     data_subsets: List = []
     for df in [noisy_df, not_noisy_df]:

--- a/eevee/metrics/asr.py
+++ b/eevee/metrics/asr.py
@@ -656,16 +656,16 @@ def asr_report(
 
 
 def extract_info_tags(transcription: str) -> str:
-    pass
+    return ""
 
 
 def clean_info_tags(transcription: str) -> str:
-    pass
+    return ""
 
 
 ## change this if you want to change the definition of noisy
 def define_noisy(tag):
-    if tag is None:
+    if tag == "":
         return 0
     elif "silent" in tag:
         return 0
@@ -678,15 +678,19 @@ def process_noise_info(
 ) -> Tuple[Dict[str, pd.DataFrame], Dict[str, pd.DataFrame]]:
 
     df = pd.merge(true_labels, pred_labels, on="id", how="inner")
+
+    # Since empty items in true transcription is read as NaN, we have to
+    # replace them
+    df["transcription"] = df["transcription"].fillna("")
     
     ## separate out info tags in transcripts and clean the original transcriptions
-    df["info-tag"] = df["transcription"].apply(lambda trancription: extract_info_tags(trancription))
+    df["info-tag"] = df["transcription"].apply(lambda transcription: extract_info_tags(transcription))
     df["cleaned-transcription"] = df["transcription"].apply(lambda transcription: clean_info_tags(transcription))
     
     ## separate noisy and not-noisy subsets
     df["noise-label"] = df["info-tag"].apply(lambda tag: define_noisy(tag))
     noisy_df = df[df["noise-label"] == 1]
-    not_noisy_df = df[df["noise-label"] == 0]
+    not_noisy_df = df[df["noise-label"] != 1]
     
     data_subsets: List = []
     for df in [noisy_df, not_noisy_df]:

--- a/eevee/metrics/asr.py
+++ b/eevee/metrics/asr.py
@@ -690,6 +690,6 @@ def process_noise_info(
     
     data_subsets: List = []
     for df in [noisy_df, not_noisy_df]:
-        data_subsets.append({"true": df[["id", "transcription"]], "pred": df[["id", "utterances"]]})
+        data_subsets.append({"true": df[["id", "cleaned-transcription"]], "pred": df[["id", "utterances"]]})
         
     return tuple(data_subsets)

--- a/eevee/metrics/asr.py
+++ b/eevee/metrics/asr.py
@@ -6,10 +6,6 @@ from functools import reduce
 from operator import mul
 from typing import Any, Dict, List, Mapping, Tuple, Union
 
-from pandas import Series, DataFrame
-from pandas.core.arrays import ExtensionArray
-from pandas.core.generic import NDFrame
-
 import eevee.transforms as tr
 import Levenshtein
 import numpy as np

--- a/eevee/metrics/asr.py
+++ b/eevee/metrics/asr.py
@@ -649,3 +649,7 @@ def asr_report(
 
     else:
         return report
+
+
+def process_noise_info(true_labels: pd.DataFrame, pred_labels: pd.DataFrame):
+    pass

--- a/tests/asr/test_process_noise_info.py
+++ b/tests/asr/test_process_noise_info.py
@@ -1,0 +1,15 @@
+from eevee.metrics.asr import extract_info_tags, clean_info_tags, define_noisy
+
+
+def test_process_noise_info():
+
+	clean_transcription = "This is an example"
+	noise_tags = ["", "['<audio_silent>']", "['<inauidble>']", "['<background_speech>']"]
+	noise_labels = [0, 0, 1, 1]
+
+	noisy_transcriptions = ["{}{}".format(clean_transcription, tag) for tag in noise_tags]
+
+	for transcription, tag, label in zip(noisy_transcriptions, noise_tags, noise_labels):
+		assert extract_info_tags(transcription) == tag
+		assert clean_info_tags(transcription) == clean_transcription
+		assert define_noisy(tag) == label

--- a/tests/asr/test_process_noise_info.py
+++ b/tests/asr/test_process_noise_info.py
@@ -4,12 +4,13 @@ from eevee.metrics.asr import extract_info_tags, remove_info_tags, define_noisy
 def test_process_noise_info():
 
 	clean_transcription = "This is an example"
-	noise_tags = ["", "['<audio_silent>']", "['<inauidble>']", "['<background_speech>']"]
+	noise_tags = ["", "<audio_silent>", "<inauidble>", "<background_speech>"]
 	noise_labels = [0, 0, 1, 1]
 
 	noisy_transcriptions = ["{}{}".format(clean_transcription, tag) for tag in noise_tags]
 
 	for transcription, tag, label in zip(noisy_transcriptions, noise_tags, noise_labels):
-		assert extract_info_tags(transcription) == tag
+		tags = [tag] if tag != "" else []
+		assert extract_info_tags(transcription) == tags
 		assert remove_info_tags(transcription) == clean_transcription
-		assert define_noisy(tag) == label
+		assert define_noisy(tags) == label

--- a/tests/asr/test_process_noise_info.py
+++ b/tests/asr/test_process_noise_info.py
@@ -1,4 +1,4 @@
-from eevee.metrics.asr import extract_info_tags, remove_info_tags, define_noisy
+from eevee.metrics.asr import extract_info_tags, remove_info_tags, check_if_tags_is_noisy
 
 
 def test_process_noise_info():
@@ -13,4 +13,4 @@ def test_process_noise_info():
 		tags = [tag] if tag != "" else []
 		assert extract_info_tags(transcription) == tags
 		assert remove_info_tags(transcription) == clean_transcription
-		assert define_noisy(tags) == label
+		assert check_if_tags_is_noisy(tags) == label

--- a/tests/asr/test_process_noise_info.py
+++ b/tests/asr/test_process_noise_info.py
@@ -1,4 +1,4 @@
-from eevee.metrics.asr import extract_info_tags, clean_info_tags, define_noisy
+from eevee.metrics.asr import extract_info_tags, remove_info_tags, define_noisy
 
 
 def test_process_noise_info():
@@ -11,5 +11,5 @@ def test_process_noise_info():
 
 	for transcription, tag, label in zip(noisy_transcriptions, noise_tags, noise_labels):
 		assert extract_info_tags(transcription) == tag
-		assert clean_info_tags(transcription) == clean_transcription
+		assert remove_info_tags(transcription) == clean_transcription
 		assert define_noisy(tag) == label


### PR DESCRIPTION
Implements this functionality through:

- [x] an alternate entry point via CLI - `eevee asr --noisy`
- [x] a cleaning method to separate out the info tags from every utterance
- [ ] ~optionally, a yaml to define the noisy and non-noisy subsets~
- [x] add documentation for usage